### PR TITLE
capture audio in rtmp stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.21-alpine as builder
 WORKDIR /chromestage
 
-COPY go.mod . 
+COPY go.mod .
 COPY go.sum .
 
 RUN apk add --no-cache ca-certificates git
@@ -22,7 +22,10 @@ RUN apt-get update
 RUN apt-get -y install wget --fix-missing
 RUN apt-get -y install xvfb xorg x11vnc firefox xterm dbus-x11 xfonts-100dpi xfonts-75dpi xfonts-cyrillic --fix-missing # chrome will use this to run headlessly
 RUN apt-get -y install unzip xterm --fix-missing
+RUN apt-get -y install pulseaudio
 RUN apt-get -y install ffmpeg
+
+RUN adduser root pulse-access
 
 # install go
 RUN wget -O - 'https://storage.googleapis.com/golang/go1.21.3.linux-amd64.tar.gz' | tar xz -C /usr/local/

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	"github.com/chromedp/chromedp"
 )
@@ -55,10 +56,12 @@ func main() {
 	// ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
 	// defer cancel()
 
+	startPage := os.Args[1]
+
 	// navigate to a page, wait for an element, click
 	var example string
 	err := chromedp.Run(ctx,
-		chromedp.Navigate(`https://pkg.go.dev/time`),
+		chromedp.Navigate(startPage),
 		// wait for footer element is visible (ie, page is loaded)
 		chromedp.WaitVisible(`body > footer`),
 		// find and click "Example" link

--- a/start.sh
+++ b/start.sh
@@ -30,6 +30,7 @@ if [ -n "$stream_url" ]; then
     -f x11grab -video_size 1280x720 -framerate 30 -i $DISPLAY \
     -f alsa -i pulse -ac 2 \
     -c:v libx264 -preset veryfast -c:a aac -strict experimental \
+    -copyts \
     -f flv "$stream_url"
 else
   cat

--- a/start.sh
+++ b/start.sh
@@ -3,26 +3,34 @@
 # mkdir -p /run/dbus/
 # export DBUS_FATAL_WARNINGS=0
 # dbus-daemon --system
+stream_url="${1:-}"
+default_start='https://pkg.go.dev/time'
+start_page="${2:-"$default_start"}"
+
 echo "starting xvfb..."
 Xvfb $DISPLAY -ac -screen 0 $XVFB_WHD -nolisten tcp &
 sleep 1
+
+echo "starting pulseaudio..."
+pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
+
 # echo "starting xterm..."
 # xterm -maximized &
 echo "starting chrome..."
 google-chrome --no-sandbox --no-default-browser-check --remote-debugging-port=9222 --window-position=0,0 --window-size=1280,720 --no-first-run --kiosk  & # --start-maximized --start-fullscreen
 sleep 1
 echo "starting chromestage..."
-/bin/chromestage &
-sleep 1
+/bin/chromestage "$start_page" &
 echo "starting x11vnc..."
 x11vnc -display $DISPLAY -forever -passwd chromestage &
 sleep 1
-if [ -n "$1" ]; then
+if [ -n "$stream_url" ]; then
   echo "starting ffmpeg..."
   ffmpeg \
     -f x11grab -video_size 1280x720 -framerate 30 -i $DISPLAY \
-    -f lavfi -i anullsrc=r=44100:cl=stereo -c:v libx264 -preset veryfast -c:a aac -strict experimental \
-    -f flv $1
+    -f alsa -i pulse -ac 2 \
+    -c:v libx264 -preset veryfast -c:a aac -strict experimental \
+    -f flv "$stream_url"
 else
   cat
 fi


### PR DESCRIPTION
Captures audio from the container and adds it to the RTMP stream.

Also adds an argument to change the Chrome start page for easier testing.

Testing process:

Launch an RTMP server to capture the stream:
docker run -it -p 1935:1935 -p 8080:8080 --name rtmp alqutami/rtmp-hls:latest-alpine

Start chromestage to stream to the RTMP server with a video file:
docker run -ti -p 5900:5900 chromestage rtmp://172.17.0.2/live/test https://dl6.webmfiles.org/big-buck-bunny_trailer.webm

In VLC, use "Open Network..." to connect to the stream:
rtmp://localhost:1935/live/test
