### PR TITLE
run chrome as a regular user to remove the sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,15 @@ EXPOSE 5900
 # chromedp
 EXPOSE 9222
 
+RUN groupadd -r chromium && useradd -r -g chromium -G audio,video,pulse-access chromium \
+  && mkdir -p /home/chromium/Downloads && chown -R chromium:chromium /home/chromium
+
 RUN apt-get install -y ca-certificates tzdata
 COPY --from=builder /go/bin /bin
-COPY /start.sh /
-RUN chmod +x /start.sh
-ENTRYPOINT ["/start.sh"]
+COPY /start.sh /home/chromium/start.sh
+RUN chmod +x /home/chromium/start.sh
+
+# Run as non privileged user
+USER chromium
+WORKDIR /home/chromium
+ENTRYPOINT ["/home/chromium/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -12,13 +12,13 @@ Xvfb $DISPLAY -ac -screen 0 $XVFB_WHD -nolisten tcp &
 sleep 1
 
 echo "starting pulseaudio..."
-pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
+pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit
 
 # echo "starting xterm..."
 # xterm -maximized &
 echo "starting chrome..."
-google-chrome --no-sandbox --no-default-browser-check --remote-debugging-port=9222 --window-position=0,0 --window-size=1280,720 --no-first-run --kiosk  & # --start-maximized --start-fullscreen
-sleep 1
+google-chrome --disable-gpu --no-default-browser-check --remote-debugging-port=9222 --window-position=0,0 --window-size=1280,720 --no-first-run --disable-dev-shm-usage --kiosk  & # --start-maximized --start-fullscreen
+sleep 10
 echo "starting chromestage..."
 /bin/chromestage "$start_page" &
 echo "starting x11vnc..."


### PR DESCRIPTION
Update the Dockerfile and commands to run Chrome as a normal user with the sandbox. This seems to help with some of the issues with Chrome crashing when loading more complex pages.

I was able to test signing in to the Greenlight workspace with VLC, then getting video and audio from the FFMPEG stream.

Some of the Chrome flag changes may not be necessary, I can revisit to try again without some of these.